### PR TITLE
Update clientVersion

### DIFF
--- a/src/registerSurvey.ts
+++ b/src/registerSurvey.ts
@@ -51,7 +51,7 @@ export async function registerSurvey(endpoint: string, token: string, survey: Su
 }): Promise<SurveyResult> {
     const user = await userInfo(endpoint, token)
     const data = {
-        clientVersion: '1.8.8',
+        clientVersion: '1.8.9',
         deviceUuid: '',
         rspns00: (!survey.Q1 && survey.Q2 !== CovidQuickTestResult.NONE && !survey.Q3) ? 'Y' : 'N',
         rspns01: survey.Q1 ? '2' : '1',


### PR DESCRIPTION
```js
{
  isError: true,
  message: '정상적인 설문결과 등록이 아닙니다. 클라이언트 버전이 일치하지 않습니다. 앱을 재실행하시거나 브라우저 새로고침을 해주세요.[3004]'
}
```
1.8.8 to 1.8.9
버전이 자주 변경된다면 클라이언트 버전을 받아올 수 있는 다른 방법을 모색해 봐야 할 것 같습니다.