### PR TITLE
1.9.5 업데이트 이후 SearchKey가 필요합니다.

### DIFF
--- a/docs/docs/api/School.mdx
+++ b/docs/docs/api/School.mdx
@@ -16,5 +16,7 @@ sidebar_position: 1
     endpoint: string
     /** 학교식별번호 */
     schoolCode: string
+    /** 학교 검색 인증 키 */
+    searchKey: string
 }
 ```

--- a/docs/docs/methods/login.mdx
+++ b/docs/docs/methods/login.mdx
@@ -12,7 +12,7 @@ sidebar_position: 2
 const name = "엄준식" // 학생 이름
 const birthday = "040309" // 생년월일 6자리
 
-const login = await hcs.login(school.endpoint, school.schoolCode, name, birth)
+const login = await hcs.login(school.endpoint, school.schoolCode, name, birth, school.searchKey)
 ```
 
 ### 결과 예시

--- a/docs/docs/methods/searchSchool.mdx
+++ b/docs/docs/methods/searchSchool.mdx
@@ -23,7 +23,8 @@ const schools = await hcs.searchSchool("서울과학고")
   city: "서울특별시",
   address: "(03066)서울특별시 종로구 혜화로 63 (명륜1가)",
   endpoint: "senhcs.eduro.go.kr",
-  schoolCode: "B100000569"
+  schoolCode: "B100000569",
+  searchKey: "학교 검색 인증 키"
 },
 {
   // ...

--- a/example.ts
+++ b/example.ts
@@ -27,7 +27,7 @@ const example = async () => {
     console.log('생년월일 6자리를 입력해주세요.')
     const birthday = (await it.next()).value
 
-    const login = await hcs.login(school.endpoint, school.schoolCode, name, birthday)
+    const login = await hcs.login(school.endpoint, school.schoolCode, name, birthday, school.searchKey)
     if (!login.success) {
         console.log('로그인에 실패했습니다.')
         process.exit(0)

--- a/src/login.ts
+++ b/src/login.ts
@@ -56,21 +56,21 @@ export interface LoginResultFailure {
  * @param schoolCode 학교식별번호
  * @param name 학생명
  * @param birthday 생년월일
+ * @param searchKey 학교 검색 인증 키
  * @returns {Promise<LoginResult>}
  */
-export async function login(endpoint: string, schoolCode: string, name: string, birthday: string): Promise<LoginResult> {
+export async function login(endpoint: string, schoolCode: string, name: string, birthday: string, searchKey: string): Promise<LoginResult> {
     const data = {
         birthday: encrypt(birthday),
         loginType: 'school',
         name: encrypt(name),
         orgCode: schoolCode,
-        stdntPNo: null
+        stdntPNo: null,
+        searchKey: searchKey
     }
     const response = await fetchHcs('/v2/findUser', 'POST', data, endpoint)
-    return response['isError'] ? {
-        success: false,
-        message: response['message']
-    } : {
+    if (!response.token || response['isError']) return { success: false, message: response['message'] }
+    return {
         success: true,
         agreementRequired: response['pInfAgrmYn'] === 'N',
         schoolName: response['orgName'],

--- a/src/searchSchool.ts
+++ b/src/searchSchool.ts
@@ -14,6 +14,8 @@ export interface School {
     endpoint: string
     /** 학교식별번호 */
     schoolCode: string
+    /** 학교 검색 인증 키 */
+    searchKey: string
 }
 
 /**
@@ -31,7 +33,8 @@ export async function searchSchool(schoolName: string): Promise<School[]> {
             city: school["lctnScNm"],
             address: school["addres"],
             endpoint: school["atptOfcdcConctUrl"],
-            schoolCode: school["orgCode"]
+            schoolCode: school["orgCode"],
+            searchKey: response.key
         }
     })
 }


### PR DESCRIPTION
```js
// /v2/searchSchool 응답 
{
    "schulList": [
        {
           // 학교 정보
        }
    ],
    "sizeover": false,
    "key": "0156DA8A6 ..." // SearchKey, findUser서 요구됩니다.
}
```
1.9.5 업데이트 이후 `/v2/searchSchool` 요청 응답에 `key` 항목이 반환됩니다.
해당 `key` 항목은 `/v2/findUser` 요청서 요구됩니다.
```js
// /v2/findUser 요청 body 
{
    "birthday": "",
    "loginType": "",
    "name": "",
    "orgCode": "",
    "stdntPNo": null,
    "searchKey": "0156DA8A6 ..." // SearchKey
}
```
해당 사항을 해결하기 위해 hcs 모듈 내 `hcs.searchSchool`함수에서 `searchKey`를 반환하고 `hcs.login`함수에서 `searchKey`를 필요로  하도록 수정하였습니다.
```js
// searchSchool
/** 학교 정보 */
export interface School {
    /** 학교명 */
    name: string
    /** 학교명(영문) */
    nameEn: string
    /** 관할 시/도 */
    city: string
    /** 학교 주소 */
    address: string
    /** 관할 시/도 엔드포인트 */
    endpoint: string
    /** 학교식별번호 */
    schoolCode: string
    /** 학교 검색 인증 키 */
    searchKey: string
}
```
```js
// login
/**
 * 1차 로그인을 진행합니다.
 * @param endpoint 관할 시/도 엔드포인트
 * @param schoolCode 학교식별번호
 * @param name 학생명
 * @param birthday 생년월일
 * @param searchKey 학교 검색 인증 키
 * @returns {Promise<LoginResult>}
 */
```